### PR TITLE
Webhooks: sending WME Chat messages to other chat services

### DIFF
--- a/webserver_history/lib-webhooks.php
+++ b/webserver_history/lib-webhooks.php
@@ -1,0 +1,88 @@
+<?php
+
+$configs = @json_decode(file_get_contents("configs.json"));
+if ($configs == null) {
+	$configs = new stdClass();
+	// webhooks not configured - see comment below
+}
+	
+/* configs.json contains details of all the rooms and webhooks:
+{
+	"<room name>" : {
+		"type" : "<Console | Slack | Discord>",
+		"webhook" : "<url>",
+		"contact" : "<name of person with webhook details>"
+	},
+	// repeat for each room
+}
+*/
+
+function sendToWebhook($room, $username, $message) {
+	global $configs;
+
+	if (!array_key_exists($room, $configs)) {
+		return false; // no webhook config for this room
+	}
+	$config = $configs->{$room};
+
+	// send message depending on the type of webhook
+	if ($config->type == "Console") {
+		$ok = sendToConsole($config, $username, $message);
+	}
+	else if ($config->type == "Slack") {
+		$ok = sendToSlack($config, $username, $message);
+	}
+	else if ($config->type == "Discord") {
+		$ok = sendToDiscord($config, $username, $message);
+	}
+	else {
+		$ok = false; // unexpected type
+	}
+
+	return $ok;
+}
+
+function sendToConsole($config, $username, $message) {
+	printf("| *%s* _%s_\n", $username, $message);
+	return true;
+}
+
+function sendToSlack($config, $username, $message) {
+	// format the message for Slack
+	$message = sprintf("*%s* %s", $username, $message);
+
+	// build the payload for the webhook
+	$data_string = json_encode([ 'text' => $message ]);
+
+	// create the POST request to webhook
+	$ch = curl_init($config->webhook);
+	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+	curl_setopt($ch, CURLOPT_POSTFIELDS, $data_string);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+		'Content-Type: application/json',
+		'Content-Length: ' . strlen($data_string))
+	);
+
+	// engage!
+	$result = curl_exec($ch);
+	if (!$result) {
+		#print "- Error sending message to Slack\n";
+		return false;
+	}
+
+	curl_close($ch);
+
+	if ($result == 'ok') {
+		return true;
+	}
+
+	#print "- Failed to send message to Slack\n";
+	return false;
+}
+
+function sendToDiscord($config, $username, $message) {
+	// TODO
+}
+
+?>

--- a/webserver_history/lib-webhooks.php
+++ b/webserver_history/lib-webhooks.php
@@ -25,6 +25,9 @@ function sendToWebhook($room, $username, $message) {
 	}
 	$config = $configs->{$room};
 
+	// decode &quot; etc
+	$message = html_entity_decode($message);
+
 	// send message depending on the type of webhook
 	if ($config->type == "Console") {
 		$ok = sendToConsole($config, $username, $message);
@@ -43,7 +46,7 @@ function sendToWebhook($room, $username, $message) {
 }
 
 function sendToConsole($config, $username, $message) {
-	printf("| *%s* _%s_\n", $username, $message);
+	printf("| %s: %s\n", $username, $message);
 	return true;
 }
 

--- a/webserver_history/lib-webhooks.php
+++ b/webserver_history/lib-webhooks.php
@@ -82,7 +82,24 @@ function sendToSlack($config, $username, $message) {
 }
 
 function sendToDiscord($config, $username, $message) {
-	// TODO
+	// build the payload for the webhook
+	$data_string = json_encode([ 'username' => $username, 'content' => $message ]);
+
+	// create the POST request to webhook
+	$ch = curl_init($config->webhook);
+	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+	curl_setopt($ch, CURLOPT_POSTFIELDS, $data_string);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+		'Content-Type: application/json',
+		'Content-Length: ' . strlen($data_string))
+	);
+
+	// engage!
+	$result = curl_exec($ch);
+
+	// assume it sent fine
+	return true;
 }
 
 ?>

--- a/webserver_history/postHistory.php
+++ b/webserver_history/postHistory.php
@@ -11,6 +11,7 @@ function endsWith($haystack, $needle) {
 }
 */
 
+include ('lib-webhooks.php');
 
 function startsWith($haystack,$needle) 
 { 
@@ -539,7 +540,9 @@ for ($i=0; $i<count($data); $i++)
 		my_var_dump("result", $result);
 		if (!$result)
 			my_var_dump("MySQL error:", mysqli_error());
-
+			
+		// webhook integration
+		sendToWebhook($data[$i]['room'], $data[$i]['username'], $data[$i]['message']);
 	}
 	$query="UNLOCK TABLES";
 	$result = mysqli_query($link, $query);

--- a/webserver_history/test-webhooks.php
+++ b/webserver_history/test-webhooks.php
@@ -1,0 +1,42 @@
+<?php
+include("lib-webhooks.php");
+
+foreach ($configs as $room => $config) {
+	$configs->{$room}->type = 'Console'; // testing
+	
+	// fetch the history from WazeDev
+	$url = sprintf("https://wazedev.com/chataddon/clog/getHistory.php?room=%s", urlencode($room));
+	$chatlog = trim(file_get_contents($url));
+	if (!$chatlog) {
+		print "ERROR: failed to fetch log for $config->room\n";
+		continue;
+	}
+
+	// remove bogus characters at beginning of the feed
+	$chatlog = preg_replace('/^[\x00-\x1F\x80-\xFF]*/', '', $chatlog);
+
+	// decode json
+	$data = json_decode($chatlog, false, 512, JSON_THROW_ON_ERROR);
+	if ($data === null) {
+		printf("ERROR: failed to parse json: %s\n", json_last_error_msg());
+		continue;
+	}
+
+	printf("[%s] %s:\n", strftime('%T'), $room);
+	
+	// read messages from history
+	$count = 0;
+	foreach ($data as $chat) {
+		// send message depending on the type of webhook
+		$ok = sendToWebhook($room, $chat->username, $chat->message);
+		if ($ok) {
+			$count++;
+		}
+	}
+
+	if ($count > 0) {
+		printf("[%s] %s: Sent %d messages to %s\n", strftime('%T'), $room, $count, $config->type);
+	}
+}
+
+?>


### PR DESCRIPTION
This change adds the ability for _postHistory.php_ to send each new message out to another service, such as Slack or Discord.
Configuration is done in a separate json file that defines the webhook for each room by name:
```
{
  "United Kingdom" : {
    "type" : "Slack",
    "webhook" : "https://hooks.slack.com/services/.../.../...",
    "contact" : "Jim"
  },
  "United States" : {
    "type" : "Discord",
    "webhook" : "https://discord.com/api/webhooks/.../...",
    "contact" : "Bob"
  }
}
```
Note: this file is **not** to stored in source control, as it contains tokens that must remain private.